### PR TITLE
refactor(server): Standardize routing and separate API from page views

### DIFF
--- a/routes/pageRoutes.js
+++ b/routes/pageRoutes.js
@@ -78,11 +78,15 @@ router.get("/contact", (req, res) => {
   res.render("contact", { title: "Contact • SkillLink" });
 });
 
+// Handle contact form submission
+router.get('/register', (req, res) => res.render('register', { title: 'Sign Up • SkillLink' }));
+router.get('/login', (req, res) => res.render('login', { title: 'Log In • SkillLink' }));
 
 router.post("/contact", (req, res) => {
   console.log("Contact form:", req.body);
   res.render("contact", { title: "Contact • SkillLink", sent: true });
 });
+
 
 
 // // Services

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -1,19 +1,15 @@
-const express = require('express');
+ const express = require('express');
 const router = express.Router();
 const { registerUser, loginUser } = require('../controllers/userController');
 const { protect } = require('../middleware/authMiddleware'); // Middleware to protect routes
 
-// Render views
-router.get('/register', (req, res) => res.render('auth/register', { title: 'Sign Up • SkillLink' }));
-router.get('/login', (req, res) => res.render('auth/login', { title: 'Log In • SkillLink' }));
-
-// Define the POST route for registering a new user
+// API endpoint for registering a new user define the POST route for registering a new user
 router.post('/register', registerUser);
 
-// Define the POST route for logging in a user
+// API endpoint for logging in a user, define the POST route for logging in a user
 router.post('/login', loginUser);
 
-// Protected route - only accessible if the user provides a valid token
+// API endpoint for getting user profile protected route - only accessible if the user provides a valid token
 router.get('/profile', protect, (req, res) => {
   res.status(200).json({
     message: 'You have access to this protected data!',

--- a/server.js
+++ b/server.js
@@ -3,63 +3,56 @@ const express = require('express');
 const dotenv = require('dotenv');
 const expressLayouts = require('express-ejs-layouts');
 const connectDB = require('./config/db');
+
+// --- Import Route Files ---
+const pageRoutes = require("./routes/pageRoutes");
 const userRoutes = require('./routes/userRoutes');
 const serviceRoutes = require('./routes/serviceRoutes');
-const Service = require('./models/service');
+const reviewRoutes = require('./routes/reviewRoutes'); // Assuming you created this in the previous steps
 
-// Load environment variables
-
+// --- Core Setup ---
 dotenv.config();
-
-const pageRoutes = require("./routes/pageRoutes"); // <-- home/about/contact
-
 connectDB();
-
 const app = express();
+
+// --- Middleware ---
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
 app.use(express.static(path.join(__dirname, "public")));
 
-// View engine (EJS)
-app.set('views', path.join(__dirname, 'views'));
+// --- View Engine Setup ---
 app.set('view engine', 'ejs');
-/* EJS */
-app.set("views", path.join(__dirname, "views"));
-app.set("view engine", "ejs");
+app.set('views', path.join(__dirname, 'views'));
 app.use(expressLayouts);
-
 app.set('layout', 'layouts/main');
 
-// Locals available in all EJS views
+// --- Global Variables for Views ---
 app.use((req, res, next) => {
-  res.locals.user = req.user || null; // set to req.user when auth is added
+  res.locals.user = req.user || null;
   res.locals.title = 'SkillLink';
   next();
 });
 
-// Routes
-app.use('/', userRoutes);
+// --- ROUTES ---
+// Page-rendering routes (handled by pageRoutes.js)
+app.use('/', pageRoutes);
+
+// API routes (prefixed with /api)
+app.use('/api/users', userRoutes);
 app.use('/api/services', serviceRoutes);
+app.use('/api/reviews', reviewRoutes);
 
 
-// render the create service form
-app.get('/services/new', (req, res) => {
-  res.render('createService');
+// --- 404 Handler (Must be last) ---
+app.use((_req, res) => {
+    res.status(404).send("Error 404: Page Not Found");
 });
 
-/* Routes */
-app.use("/", pageRoutes);
-app.use("/auth", userRoutes);
-
-
-/* 404 LAST */
-app.use((_req, res) => res.status(404).send("Not Found"));
-
+// --- Server Initialization ---
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () =>
+const server = app.listen(PORT, () =>
   console.log(`Server running on http://localhost:${PORT}`)
 );
 
-
-
-
+// Export for testing purposes
+module.exports = { app, server };


### PR DESCRIPTION
## This pull request addresses critical routing conflicts in `server.js` and refactors our route files to establish a clear and maintainable separation between page-rendering logic and the backend API.

---

### What this PR does

#### `server.js` Cleanup
- Removes all individual route handlers from the main server file.  
- Eliminated some duplicate view engine configurations.  
- Implements a clean, top-level routing structure:
  - `app.use('/', pageRoutes)` → all user-facing pages  
  - `app.use('/api/users', userRoutes)` → user-related API endpoints  
  - `app.use('/api/services', serviceRoutes)` → service-related API endpoints  

#### `userRoutes.js` Refactor
- Now is **exclusively** for API endpoints (e.g., `POST /register`, `POST /login`).  
- All page-rendering routes (`GET /register`, `GET /login`) have been moved out.  

#### `pageRoutes.js` 
- Now the single source for rendering all **EJS views**.  
- also Includes routes for displaying the login and register pages.  
