### PR TITLE
feat: implement booking acceptance and decline buttons and other implementations

### DIFF
--- a/controllers/bookingController.js
+++ b/controllers/bookingController.js
@@ -16,20 +16,26 @@ exports.createBooking = async (req, res) => {
     if (!service) return res.status(404).json({ message: "Service not found" });
 
     if (String(service.user) === String(requesterId)) {
-      return res.status(400).json({ message: "You cannot book your own service." });
+      return res
+        .status(400)
+        .json({ message: "You cannot book your own service." });
     }
 
-    if (typeof req.user.credits === "number" &&
-        typeof service.credits === "number" &&
-        req.user.credits < service.credits) {
-      return res.status(400).json({ message: "You do not have enough credits for this service." });
+    if (
+      typeof req.user.credits === "number" &&
+      typeof service.credits === "number" &&
+      req.user.credits < service.credits
+    ) {
+      return res
+        .status(400)
+        .json({ message: "You do not have enough credits for this service." });
     }
 
     const newBooking = await Booking.create({
       service: serviceId,
       requester: requesterId,
       provider: service.user,
-      status: "Pending"
+      status: "Pending",
     });
 
     return res.status(201).json({
@@ -71,41 +77,44 @@ exports.listBookings = async (req, res) => {
 exports.acceptBooking = async (req, res) => {
   try {
     const booking = await Booking.findById(req.params.id)
-      .populate("requester")
-      .populate("provider")
-      .populate("service");
-
+      .populate("requester provider service");
     if (!booking) return res.status(404).json({ message: "Booking not found" });
     if (String(booking.provider._id) !== String(req.user._id)) {
       return res.status(403).json({ message: "Forbidden: not the provider" });
     }
 
-    // Update status
     booking.status = "Accepted";
 
-    // Deduct credits from requester (if you use credits)
-    if (typeof booking.requester.credits === "number" &&
-        typeof booking.service.credits === "number") {
-      booking.requester.credits -= booking.service.credits;
-      await booking.requester.save();
-    }
-
-    // Create a message thread
-    await MessageThread.create({
-      participants: [booking.requester._id, booking.provider._id],
-      messages: [{
-        sender: booking.provider._id,
-        body: `Hi! I've accepted your request for "${booking.service.title}". Let's arrange a time.`,
-      }],
-    });
-
+    // (optional) credit handling here...
     await booking.save();
+
+    const participants = [
+      booking.requester._id.toString(),
+      booking.provider._id.toString()
+    ].sort();
+
+    await MessageThread.findOneAndUpdate(
+      { booking: booking._id },
+      {
+        $setOnInsert: { booking: booking._id, participants },
+        $push: {
+          messages: {
+            sender: booking.provider._id,
+            body: `Hi! I've accepted your request for "${booking.service.title}". Let's arrange a time.`,
+            createdAt: new Date()
+          }
+        }
+      },
+      { upsert: true, new: true }
+    );
+
     return res.status(200).json({ message: "Booking accepted", booking });
   } catch (err) {
     console.error(err);
     return res.status(500).json({ message: "Server Error" });
   }
 };
+
 
 /**
  * @desc    Provider declines a booking
@@ -135,26 +144,40 @@ exports.declineBooking = async (req, res) => {
 exports.postMessage = async (req, res) => {
   try {
     const booking = await Booking.findById(req.params.id)
-      .populate("requester")
-      .populate("provider");
+      .populate("requester provider");
 
     if (!booking) return res.status(404).json({ message: "Booking not found" });
 
+    const me = String(req.user._id);
     const isParticipant =
-      String(req.user._id) === String(booking.requester._id) ||
-      String(req.user._id) === String(booking.provider._id);
+      me === String(booking.requester._id) || me === String(booking.provider._id);
+    if (!isParticipant) return res.status(403).json({ message: "Forbidden: not a participant" });
 
-    if (!isParticipant) {
-      return res.status(403).json({ message: "Forbidden: not a participant" });
-    }
-
-    const text = (req.body && req.body.text || "").trim();
+    const text = (req.body?.text || "").trim();
     if (!text) return res.status(400).json({ message: "Message text required" });
 
-    // Upsert/find a thread and append message (simplified)
+    // Stable, sorted participant order (nice to keep consistent)
+    const participants = [
+      booking.requester._id.toString(),
+      booking.provider._id.toString()
+    ].sort();
+
+    // Upsert by booking id; set insert-only fields explicitly
     const thread = await MessageThread.findOneAndUpdate(
-      { participants: { $all: [booking.requester._id, booking.provider._id] } },
-      { $push: { messages: { sender: req.user._id, body: text } } },
+      { booking: booking._id },
+      {
+        $setOnInsert: {
+          booking: booking._id,
+          participants
+        },
+        $push: {
+          messages: {
+            sender: req.user._id,
+            body: text,
+            createdAt: new Date()
+          }
+        }
+      },
       { upsert: true, new: true }
     );
 
@@ -175,39 +198,50 @@ exports.updateBookingStatus = async (req, res) => {
   const bookingId = req.params.id;
 
   try {
-    const booking = await Booking.findById(bookingId)
-      .populate("requester provider service");
+    const booking = await Booking.findById(bookingId).populate(
+      "requester provider service"
+    );
 
     if (!booking) return res.status(404).json({ message: "Booking not found" });
     if (String(booking.provider._id) !== String(req.user._id)) {
-      return res.status(403).json({ message: "Forbidden: You are not the provider" });
+      return res
+        .status(403)
+        .json({ message: "Forbidden: You are not the provider" });
     }
 
     booking.status = status;
 
     if (status === "Accepted") {
-      if (typeof booking.requester.credits === "number" &&
-          typeof booking.service.credits === "number") {
+      if (
+        typeof booking.requester.credits === "number" &&
+        typeof booking.service.credits === "number"
+      ) {
         booking.requester.credits -= booking.service.credits;
         await booking.requester.save();
       }
       await MessageThread.create({
         participants: [booking.requester._id, booking.provider._id],
-        messages: [{
-          sender: booking.provider._id,
-          body: `Hi! I've accepted your request for "${booking.service.title}". Let's arrange a time.`,
-        }],
+        messages: [
+          {
+            sender: booking.provider._id,
+            body: `Hi! I've accepted your request for "${booking.service.title}". Let's arrange a time.`,
+          },
+        ],
       });
     } else if (status === "Completed") {
-      if (typeof booking.provider.credits === "number" &&
-          typeof booking.service.credits === "number") {
+      if (
+        typeof booking.provider.credits === "number" &&
+        typeof booking.service.credits === "number"
+      ) {
         booking.provider.credits += booking.service.credits;
         await booking.provider.save();
       }
     }
 
     await booking.save();
-    return res.status(200).json({ message: `Booking updated to ${status}`, booking });
+    return res
+      .status(200)
+      .json({ message: `Booking updated to ${status}`, booking });
   } catch (error) {
     console.error(error);
     return res.status(500).json({ message: "Server Error" });

--- a/controllers/serviceController.js
+++ b/controllers/serviceController.js
@@ -1,110 +1,126 @@
 // controllers/serviceController.js
+const mongoose = require("mongoose");
 const Service = require("../models/service");
 
+// Create
 exports.createService = async (req, res) => {
   try {
     const service = new Service({
       ...req.body,
-      user: req.user.id // back to logged-in user
+      user: req.user?.id, // tolerate unauth in dev
     });
-
     await service.save();
-    res.status(201).json(service);
+    // minimal UX: go to details
+    return res.redirect(`/services/${service._id}`);
   } catch (err) {
-    res.status(400).json({ error: err.message });
+    console.error(err);
+    return res.status(400).render("errors/404", { message: err.message });
   }
 };
 
-
-// Get all services
+// List (render page to match your index.ejs)
 exports.getServices = async (req, res) => {
   try {
-    const services = await Service.find();
-    res.json(services);
+    const services = await Service.find()
+      .populate("user", "firstName lastName")
+      .lean();
+    return res.render("services", { services, title: "Services" });
   } catch (err) {
-    res.status(500).json({ error: err.message });
+    console.error(err);
+    return res
+      .status(500)
+      .render("errors/404", { message: "Failed to load services" });
   }
 };
 
-// Get a service by ID
+// Detail (render page)
 exports.getServiceById = async (req, res) => {
   try {
-    const service = await Service.findById(req.params.id);
-    if (!service) return res.status(404).json({ message: "Service not found" });
-    res.json(service);
-  } catch (err) {
-    res.status(500).json({ error: err.message });
+    const { id } = req.params;
+    if (!mongoose.isValidObjectId(id)) {
+      return res
+        .status(404)
+        .render("errors/404", { message: "Invalid service id" });
+    }
+    const service = await Service.findById(id)
+      .populate("user", "firstName lastName")
+      .lean();
+
+    if (!service) {
+      return res
+        .status(404)
+        .render("errors/404", { message: "Service not found" });
+    }
+
+    // IMPORTANT: render path is relative to /views, do not prefix with "views/"
+    return res.render("services/serviceDetails", {
+      service,
+      title: service.title,
+      user: req.user || null,
+    });
+  } catch (e) {
+    console.error(e);
+    return res
+      .status(500)
+      .render("errors/404", { message: "Something went wrong" });
   }
 };
 
-// Update a service
+// --- Optional REST APIs (unchanged logic) ---
 exports.updateService = async (req, res) => {
   try {
     const service = await Service.findById(req.params.id);
+    if (!service) return res.status(404).json({ message: "Service not found" });
 
-    if (!service) {
-      return res.status(404).json({ message: "Service not found" });
+    if (
+      req.user &&
+      service.user.toString() !== req.user.id &&
+      req.user.role !== "Admin"
+    ) {
+      return res.status(401).json({ message: "User not authorized" });
     }
-
-    // --- OWNERSHIP CHECK ---
-    // A user can update if they are the owner OR if they are an admin.
-    if (service.user.toString() !== req.user.id && req.user.role !== 'Admin') {
-      return res.status(401).json({ message: 'User not authorized' });
-    }
-
-    const updatedService = await Service.findByIdAndUpdate(req.params.id, req.body, { new: true });
-    res.json(updatedService);
-
+    const updated = await Service.findByIdAndUpdate(req.params.id, req.body, {
+      new: true,
+    });
+    return res.json(updated);
   } catch (err) {
-    res.status(400).json({ error: err.message });
+    return res.status(400).json({ error: err.message });
   }
 };
 
-// Delete a service
 exports.deleteService = async (req, res) => {
   try {
     const service = await Service.findById(req.params.id);
+    if (!service) return res.status(404).json({ message: "Service not found" });
 
-    if (!service) {
-      return res.status(404).json({ message: "Service not found" });
+    if (
+      req.user &&
+      service.user.toString() !== req.user.id &&
+      req.user.role !== "Admin"
+    ) {
+      return res.status(401).json({ message: "User not authorized" });
     }
-
-    // --- OWNERSHIP CHECK ---
-    // A user can delete if they are the owner OR if they are an admin.
-    if (service.user.toString() !== req.user.id && req.user.role !== 'Admin') {
-      return res.status(401).json({ message: 'User not authorized' });
-    }
-    
-    await service.remove(); 
-    res.json({ message: "Service deleted" });
-
+    await service.deleteOne();
+    return res.json({ message: "Service deleted" });
   } catch (err) {
-    res.status(500).json({ error: err.message });
+    return res.status(500).json({ error: err.message });
   }
 };
 
-// Get services created by the logged-in user
-exports.getMyServices = async (req, res) => {
-  try {
-    const myServices = await Service.find({ user: req.user.id }).sort('-createdAt');
-    res.json(myServices);
-  } catch (err) {
-    res.status(500).json({ error: err.message });
-  }
-};
+// (You can keep your ratings methods as they were.)
 
 // Get ratings for a service (with rater details)
 exports.getRatingsForService = async (req, res) => {
   try {
     const service = await Service.findById(req.params.id)
-      .select('ratings averageRating ratingsCount')
-      .populate('ratings.user', 'firstName lastName avatar email'); // adjust fields as you like
+      .select("ratings averageRating ratingsCount")
+      .populate("ratings.user", "firstName lastName avatar email"); // adjust fields as you like
 
-    if (!service) return res.status(404).json({ message: 'Service not found' });
+    if (!service) return res.status(404).json({ message: "Service not found" });
     res.json({
       ratings: service.ratings,
       averageRating: service.averageRating,
-      ratingsCount: service.ratingsCount
+      ratingsCount: service.ratingsCount,
     });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -115,22 +131,28 @@ exports.getRatingsForService = async (req, res) => {
 const assert1to5 = (n) => Number.isFinite(n) && n >= 1 && n <= 5;
 exports.addRating = async (req, res) => {
   try {
-    const { stars, comment = '' } = req.body;
+    const { stars, comment = "" } = req.body;
 
     if (!assert1to5(stars)) {
-      return res.status(400).json({ message: 'Stars must be between 1 and 5.' });
+      return res
+        .status(400)
+        .json({ message: "Stars must be between 1 and 5." });
     }
 
     const service = await Service.findById(req.params.id);
-    if (!service) return res.status(404).json({ message: 'Service not found' });
+    if (!service) return res.status(404).json({ message: "Service not found" });
 
     // Prevent rating your own service
     if (service.user.toString() === req.user.id) {
-      return res.status(400).json({ message: 'You cannot rate your own service.' });
+      return res
+        .status(400)
+        .json({ message: "You cannot rate your own service." });
     }
 
     // If the user already rated, update that rating. Otherwise push a new one.
-    const existing = service.ratings.find(r => r.user.toString() === req.user.id);
+    const existing = service.ratings.find(
+      (r) => r.user.toString() === req.user.id
+    );
     if (existing) {
       existing.stars = stars;
       existing.comment = comment;
@@ -144,13 +166,13 @@ exports.addRating = async (req, res) => {
     await service.save();
 
     // Return fresh data with populated users
-    await service.populate('ratings.user', 'firstName lastName avatar email');
+    await service.populate("ratings.user", "firstName lastName avatar email");
 
     res.status(201).json({
-      message: 'Rating saved',
+      message: "Rating saved",
       ratings: service.ratings,
       averageRating: service.averageRating,
-      ratingsCount: service.ratingsCount
+      ratingsCount: service.ratingsCount,
     });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -162,13 +184,13 @@ exports.deleteRating = async (req, res) => {
   try {
     const { id, ratingId } = req.params; // serviceId + ratingId
     const service = await Service.findById(id);
-    if (!service) return res.status(404).json({ message: 'Service not found' });
+    if (!service) return res.status(404).json({ message: "Service not found" });
 
     const rating = service.ratings.id(ratingId);
-    if (!rating) return res.status(404).json({ message: 'Rating not found' });
+    if (!rating) return res.status(404).json({ message: "Rating not found" });
 
-    if (rating.user.toString() !== req.user.id && req.user.role !== 'Admin') {
-      return res.status(401).json({ message: 'User not authorized' });
+    if (rating.user.toString() !== req.user.id && req.user.role !== "Admin") {
+      return res.status(401).json({ message: "User not authorized" });
     }
 
     rating.remove();
@@ -176,12 +198,11 @@ exports.deleteRating = async (req, res) => {
     await service.save();
 
     res.json({
-      message: 'Rating removed',
+      message: "Rating removed",
       averageRating: service.averageRating,
-      ratingsCount: service.ratingsCount
+      ratingsCount: service.ratingsCount,
     });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
 };
-

--- a/models/service.js
+++ b/models/service.js
@@ -1,32 +1,38 @@
-const mongoose = require('mongoose');
+const mongoose = require("mongoose");
 const Schema = mongoose.Schema;
 
-const serviceSchema = new Schema({
+const serviceSchema = new Schema(
+  {
     title: { type: String, required: true, trim: true },
     description: { type: String, required: true },
     category: { type: String, required: true },
     user: {
-        type: Schema.Types.ObjectId,
-        ref: 'User',
-        required: true
+      type: Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
     },
     status: {
-        type: String,
-        enum: ['available', 'in_progress', 'completed'],
-        default: 'available'
+      type: String,
+      enum: ["available", "in_progress", "completed"],
+      default: "available",
     },
     credits: { type: Number, default: 1, min: 1 },
-    reviews: [{ // Linking servis.js to reviews
+    reviews: [
+      {
+        // Linking servis.js to reviews
         type: Schema.Types.ObjectId,
-        ref: 'Review'
-    }]
-}, { timestamps: true });
+        ref: "Review",
+      },
+    ],
+  },
+  { timestamps: true }
+);
 
 const ratingSchema = new Schema({
-  user: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+  user: { type: Schema.Types.ObjectId, ref: "User", required: true },
   stars: { type: Number, min: 1, max: 5, required: true },
-  comment: { type: String, trim: true, default: '' },
-  createdAt: { type: Date, default: Date.now }
+  comment: { type: String, trim: true, default: "" },
+  createdAt: { type: Date, default: Date.now },
 });
 
 /** Recalculate avg + count whenever ratings change */
@@ -37,5 +43,4 @@ serviceSchema.methods.recalculateRating = function () {
     : 0;
 };
 
-
-module.exports = mongoose.model('Service', serviceSchema);
+module.exports = mongoose.model("Service", serviceSchema);

--- a/public/js/bookings.js
+++ b/public/js/bookings.js
@@ -1,100 +1,124 @@
-// public/js/bookings.js
 (function () {
+  function toast(html, ms = 2000) {
+    if (window.M && M.toast) M.toast({ html, displayLength: ms });
+    else alert(html);
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    if (window.M && M.FormSelect) {
+      const elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    }
+  });
+
   function token() {
-    return localStorage.getItem('token');
+    return localStorage.getItem("token");
   }
   function authHeaders() {
-    return {
-      'Authorization': `Bearer ${token()}`,
-      'Content-Type': 'application/json'
-    };
+    const h = { "Content-Type": "application/json" };
+    const t = token();
+    if (t) h["Authorization"] = `Bearer ${t}`; // optional, cookie will still work
+    return h;
   }
   function requireLogin() {
-    M && M.toast ? M.toast({ html: 'Please log in to continue', displayLength: 2500 }) : alert('Please log in to continue');
-    window.location.href = '/login?next=' + encodeURIComponent(window.location.pathname);
+    toast("Please log in to continue", 2500);
+    window.location.href =
+      "/login?next=" + encodeURIComponent(window.location.pathname);
   }
-  function ok(res) {
-    if (res.status === 401) requireLogin();
-    if (!res.ok) throw new Error('Request failed');
-    return res.json().catch(() => ({}));
+  async function ok(res) {
+    if (res.status === 401) {
+      requireLogin();
+      throw new Error("Unauthorized");
+    }
+    if (!res.ok) throw new Error("Request failed");
+    try {
+      return await res.json();
+    } catch {
+      return {};
+    }
   }
 
   // New booking form -> POST /api/bookings/request/:serviceId
-  const newForm = document.getElementById('new-booking-form');
+  const newForm = document.getElementById("new-booking-form");
   if (newForm) {
-    newForm.addEventListener('submit', async (e) => {
+    newForm.addEventListener("submit", async (e) => {
       e.preventDefault();
-      const t = token(); if (!t) return requireLogin();
 
-      // serviceId can come from hidden input OR select
       const sel = newForm.querySelector('[name="serviceId"]');
       const serviceId = sel && sel.value ? sel.value : null;
-      if (!serviceId) return M.toast({ html: 'Please select a service', displayLength: 2500 });
+      if (!serviceId) return toast("Please select a service", 2500);
 
       try {
-        const res = await fetch(`/api/bookings/request/${serviceId}`, {
-          method: 'POST',
-          headers: authHeaders()
-          // body not required by your API; date/time/notes are currently cosmetic
+        await fetch(`/api/bookings/request/${serviceId}`, {
+          method: "POST",
+          headers: authHeaders(), // sends Bearer if present
+          credentials: "same-origin", // send httpOnly cookie
+          // body not required by your API yet
         }).then(ok);
 
-        M.toast({ html: 'Booking request sent!', displayLength: 2000 });
-        // Reload or navigate to bookings list
+        toast("Booking request sent!", 2000);
         window.location.reload();
       } catch (err) {
-        M.toast({ html: 'Booking failed', displayLength: 3000 });
         console.error(err);
+        toast("Booking failed", 3000);
       }
     });
   }
 
   // Accept / Decline buttons
-  document.querySelectorAll('.js-accept').forEach(btn => {
-    btn.addEventListener('click', async () => {
-      const t = token(); if (!t) return requireLogin();
+  document.querySelectorAll(".js-accept").forEach((btn) => {
+    btn.addEventListener("click", async () => {
       const id = btn.dataset.id;
       try {
-        await fetch(`/api/bookings/${id}/accept`, { method: 'POST', headers: authHeaders() }).then(ok);
-        M.toast({ html: 'Accepted', displayLength: 1500 });
+        await fetch(`/api/bookings/${id}/accept`, {
+          method: "POST",
+          headers: authHeaders(),
+          credentials: "same-origin",
+        }).then(ok);
+        toast("Accepted", 1500);
         window.location.reload();
-      } catch (e) {
-        M.toast({ html: 'Failed to accept', displayLength: 2500 });
+      } catch {
+        toast("Failed to accept", 2500);
       }
     });
   });
 
-  document.querySelectorAll('.js-decline').forEach(btn => {
-    btn.addEventListener('click', async () => {
-      const t = token(); if (!t) return requireLogin();
+  document.querySelectorAll(".js-decline").forEach((btn) => {
+    btn.addEventListener("click", async () => {
       const id = btn.dataset.id;
       try {
-        await fetch(`/api/bookings/${id}/decline`, { method: 'POST', headers: authHeaders() }).then(ok);
-        M.toast({ html: 'Declined', displayLength: 1500 });
+        await fetch(`/api/bookings/${id}/decline`, {
+          method: "POST",
+          headers: authHeaders(),
+          credentials: "same-origin",
+        }).then(ok);
+        toast("Declined", 1500);
         window.location.reload();
-      } catch (e) {
-        M.toast({ html: 'Failed to decline', displayLength: 2500 });
+      } catch {
+        toast("Failed to decline", 2500);
       }
     });
   });
 
   // Quick message form -> POST /api/bookings/:id/message
-  document.querySelectorAll('.js-quick-message').forEach(form => {
-    form.addEventListener('submit', async (e) => {
+  document.querySelectorAll(".js-quick-message").forEach((form) => {
+    form.addEventListener("submit", async (e) => {
       e.preventDefault();
-      const t = token(); if (!t) return requireLogin();
       const id = form.dataset.id;
-      const text = (new FormData(form).get('text') || '').trim();
+      const text = (new FormData(form).get("text") || "").trim();
       if (!text) return;
+
       try {
         await fetch(`/api/bookings/${id}/message`, {
-          method: 'POST',
+          method: "POST",
           headers: authHeaders(),
-          body: JSON.stringify({ text })
+          credentials: "same-origin",
+          body: JSON.stringify({ text }),
         }).then(ok);
-        M.toast({ html: 'Message sent', displayLength: 1500 });
+        toast("Message sent", 1500);
         form.reset();
-      } catch (e2) {
-        M.toast({ html: 'Failed to send message', displayLength: 2500 });
+      } catch {
+        toast("Failed to send message", 2500);
       }
     });
   });

--- a/routes/pageRoutes.js
+++ b/routes/pageRoutes.js
@@ -1,13 +1,12 @@
 const express = require("express");
 const router = express.Router();
-const Service = require('../models/service.js');
-const Booking = require('../models/booking.js'); // Make sure Booking model is imported
-const { protect } = require('../middleware/authMiddleware');
+const Service = require("../models/service.js");
+const Booking = require("../models/booking.js");
+const { protect } = require("../middleware/authMiddleware");
 const MessageThread = require("../models/messageThread");
-const accountController = require('../controllers/accountController');
+const accountController = require("../controllers/accountController");
 
-// Mock data for categories + featured cards on home page
-
+// ---- Mock data for home page ----
 const categories = [
   {
     icon: "code",
@@ -65,198 +64,106 @@ const featured = [
   },
 ];
 
-
-// --- PUBLIC ROUTES ---
-// Home page
-router.get('/', (req, res) => {
-  console.log('>>> pageRoutes: GET /');
-  res.render('home', { categories, featured }); 
-});
-
-// About
-router.get("/about", (req, res) => {
-  res.render("about", { title: "About • SkillLink" });
-});
-
-// Contact
-router.get("/contact", (req, res) => {
-  res.render("contact", { title: "Contact • SkillLink" });
-});
-
-// Handle contact form submission
-router.get('/register', (req, res) => res.render('register', { title: 'Sign Up • SkillLink' }));
-router.get('/login', (req, res) => res.render('login', { title: 'Log In • SkillLink' }));
-
+// --- PUBLIC PAGES ---
+router.get("/", (_req, res) => res.render("home", { categories, featured }));
+router.get("/about", (_req, res) =>
+  res.render("about", { title: "About • SkillLink" })
+);
+router.get("/contact", (_req, res) =>
+  res.render("contact", { title: "Contact • SkillLink" })
+);
 router.post("/contact", (req, res) => {
   console.log("Contact form:", req.body);
   res.render("contact", { title: "Contact • SkillLink", sent: true });
 });
 
+// Create service page
+router.get("/services/new", (_req, res) =>
+  res.render("createService", { title: "Offer a New Service" })
+);
 
-// --- LOGOUT (works whether you use cookies or localStorage) ---
-router.get('/logout', (req, res) => {
-  // if you ever switch to cookie-based auth, this clears it:
-  res.clearCookie('token');           // harmless if you don't use cookies
-  res.set('Cache-Control', 'no-store');
+// Auth pages — point to the correct subfolder under /views/auth/
+router.get("/register", (req, res) =>
+  res.render("auth/register", {
+    title: "Sign Up • SkillLink",
+    next: req.query.next || "/",
+  })
+);
+router.get("/login", (req, res) =>
+  res.render("auth/login", {
+    title: "Log In • SkillLink",
+    next: req.query.next || "/",
+  })
+);
 
-  // send a tiny page that clears storage and bounces home
-  res.send(`<!doctype html>
-<html><head><meta charset="utf-8"></head>
-<body>
+// --- LOGOUT ---
+router.get("/logout", (req, res) => {
+  res.clearCookie("token");
+  res.set("Cache-Control", "no-store");
+  res.send(`<!doctype html><meta charset="utf-8">
 <script>
-  try {
-    localStorage.removeItem('token');
-    sessionStorage.removeItem('token');
-  } catch(e) {}
-  // also nuke any stray cookie named "token"
-  document.cookie = 'token=; Max-Age=0; path=/';
-  window.location.href = '/';
-</script>
-</body></html>`);
+try { localStorage.removeItem('token'); sessionStorage.removeItem('token'); } catch(e){}
+document.cookie = 'token=; Max-Age=0; path=/';
+location.href = '/';
+</script>`);
 });
 
-
-// render the browse services page
-router.get('/services', async (req, res) => {
+// TEMP demo for my-services without protect
+router.get("/my-services", async (_req, res) => {
   try {
-    const services = await Service.find().lean(); // fetch all services
-    res.render('services', { title: "Services • Skilllink", services });
-  } catch (err) {
-    res.status(500).send('Error loading services');
-  }
-});
-
-// render the create service form
-router.get('/services/new', (req, res) => {
-  res.render('createService', { title: 'Offer a New Service' });
-});
-
-// // render the logged-in user's services
-// router.get('/my-services', async (req, res) => {
-//   try {
-//     console.log("Logged in user:", req.user); // debug log
-//     const services = await Service.find({ user: req.user._id }).lean();
-//     res.render('myServices', {
-//       title: 'My Services • Skilllink',
-//       services,
-//     });
-//   } catch (err) {
-//     console.error(err);
-//     res.status(500).send('Error loading your services');
-//   }
-// });
-// TEMP: bypass protect to debug in browser
-router.get('/my-services', async (req, res) => {
-  try {
-    // Hardcode a user ID for testing
-    const userId = '68d23e88f4ae06c337e64062'; // test2@example.com’s ID from MongoDB
+    const userId = "68d23e88f4ae06c337e64062"; // demo ID
     const services = await Service.find({ user: userId }).lean();
-
-    res.render('myServices', {
-      title: 'My Services • Skilllink',
-      services
-    });
+    res.render("myServices", { title: "My Services • SkillLink", services });
   } catch (err) {
     console.error(err);
-    res.status(500).send('Error loading your services');
-  }
-});
-
-// --- AUTH ROUTES ---
-// router.get('/register', (req, res) => res.render('auth/register', { title: 'Sign Up • SkillLink' }));
-// router.get('/login', (req, res) => res.render('auth/login', { title: 'Log In • SkillLink' }));
-
-// delete a service
-router.post('/services/:id/delete', async (req, res) => {
-  try {
-    await Service.findByIdAndDelete(req.params.id);
-    res.redirect('/my-services'); // redirect back after deleting
-  } catch (err) {
-    console.error(err);
-    res.status(500).send('Error deleting service');
+    res.status(500).send("Error loading your services");
   }
 });
 
 // --- PROTECTED ACCOUNT PAGES ---
-router.get('/dashboard', protect, accountController.getDashboard);
-router.get('/profile',   protect, accountController.getProfile);
-router.post('/profile', protect, accountController.updateProfile);
-router.get('/skills',    protect, accountController.getSkills);
-router.post('/skills',   protect, accountController.createSkill);
-router.get('/messages',  protect, accountController.getThreads);
-router.get('/messages/:threadId', protect, accountController.getThread);
-router.post('/messages/:threadId', protect, accountController.postThreadMessage); 
+router.get("/dashboard", protect, accountController.getDashboard);
+router.get("/profile", protect, accountController.getProfile);
+router.post("/profile", protect, accountController.updateProfile);
+router.get("/skills", protect, accountController.getSkills);
+router.post("/skills", protect, accountController.createSkill);
+router.get("/messages", protect, accountController.getThreads);
+router.get("/messages/:threadId", protect, accountController.getThread);
+router.post(
+  "/messages/:threadId",
+  protect,
+  accountController.postThreadMessage
+);
 
-
-// router.get("/skills", protect, async (req, res) => {
-//   try {
-//     const userSkills = await Service.find({ user: req.user._id }).lean();
-//     res.render("account/skills", { 
-//       title: "My Skills • SkillLink", 
-//       skills: userSkills 
-//     });
-//   } catch (err) {
-//     console.error(err);
-//     res.status(500).send("Server Error");
-//   }
-// });
-
-// router.get("/bookings", protect, async (req, res) => {
-//     try {
-//         const userBookings = await Booking.find({
-//             $or: [{ requester: req.user._id }, { provider: req.user._id }]
-//         })
-//         .populate('service')
-//         .populate('requester', 'username')
-//         .populate('provider', 'username')
-//         .lean();
-
-//         res.render("account/bookings", { 
-//             title: "My Bookings • SkillLink", 
-//             bookings: userBookings 
-//         });
-//     } catch (err) {
-//         console.error(err);
-//         res.status(500).send("Server Error");
-//     }
-// });
-
-// router.get("/messages", protect, async (req, res) => {
-//   const threads = await MessageThread.find({ participants: req.user.id })
-//     .populate("participants", "username")
-//     .populate("lastMessage");
-//   res.render("account/messages", { title: "Messages", threads, user: req.user });
-// });
-
-
-// Messages: simple stubs (list + one thread)
-// router.get('/messages',        (req, res) => res.render('account/messages', { title: 'Messages • SkillLink', threads: [] }));
-// router.get('/messages/:id',    (req, res) => res.render('account/thread',   { title: 'Conversation • SkillLink', threadId: req.params.id, messages: [] }));
-// router.post('/messages/:id',   (req, res) => { /* save message … */ res.redirect(`/messages/${req.params.id}`); });
-
-// router.get('/my-services', protect, async (req, res) => {
-//   try {
-//     const services = await Service.find({ user: req.user._id }).lean();
-//     res.render('myServices', {
-//       title: 'My Services • Skilllink',
-//       services
-//     });
-//   } catch (err) {
-//     console.error(err);
-//     res.status(500).send('Error loading your services');
-//   }
-// });
-
-router.post('/services/:id/delete', async (req, res) => {
+// --- Bookings page ---
+router.get("/bookings", protect, async (req, res) => {
   try {
-    await Service.findByIdAndDelete(req.params.id);
-    res.redirect('/my-services');
-  } catch (err) {
-    console.error(err);
-    res.status(500).send('Error deleting service');
+    const uid = req.user._id;
+
+    const servicesToBook = await Service.find({}).select("title price");
+    const bookings = await Booking.find({
+      $or: [{ requester: uid }, { provider: uid }],
+    })
+      .populate("service requester provider")
+      .sort({ createdAt: -1 });
+
+    const selectedService = req.query.service
+      ? await Service.findById(req.query.service)
+      : null;
+    const stats = { completed: 0, credits: 0, memberSince: "2025" };
+
+    res.render("account/bookings", {
+      user: req.user,
+      bookings,
+      servicesToBook,
+      selectedService,
+      stats,
+      flash: null,
+    });
+  } catch (e) {
+    console.error(e);
+    // Make sure you have views/error.ejs, or change to res.status(500).send(...)
+    res.status(500).render("error", { message: "Failed to load bookings" });
   }
 });
-
-
 
 module.exports = router;

--- a/routes/serviceRoutes.js
+++ b/routes/serviceRoutes.js
@@ -2,68 +2,65 @@
 const express = require("express");
 const router = express.Router();
 const serviceController = require("../controllers/serviceController");
-const { protect } = require('../middleware/authMiddleware');
+const { protect } = require("../middleware/authMiddleware");
+const Service = require("../models/service");
 
+// 🔎 quick ping to prove this router is mounted
+router.get("/__ping", (_req, res) => res.send("services router OK"));
 
-
-// Read all
+// List (renders page)
 router.get("/", serviceController.getServices);
-// Read one by ID
-router.get("/:id", serviceController.getServiceById);
 
-
-// Create
+// Create (API from form submit; protect if needed)
 router.post("/", protect, serviceController.createService);
 
-// Update
-router.put("/:id", protect, serviceController.updateService);
-
-// Delete
-router.delete("/:id", protect,  serviceController.deleteService);
-
-
-
-// Render edit service form
-router.get('/:id/edit', async (req, res) => {
+// Edit form
+router.get("/:id/edit", protect, async (req, res) => {
   try {
     const service = await Service.findById(req.params.id).lean();
-    if (!service) {
-      return res.status(404).send('Service not found');
-    }
-    res.render('editService', { service });
-  } catch (err) {
-    res.status(500).send('Error loading service');
-  }
-});
-
-// Handle service update
-router.post('/:id', async (req, res) => {
-  try {
-    const { title, description, category, status } = req.body;
-
-    await Service.findByIdAndUpdate(
-      req.params.id,
-      { title, description, category, status },
-      { new: true }
-    );
-
-    // After update, redirect back to the services list
-    res.redirect('/services');
-  } catch (err) {
-    res.status(500).send('Error updating service');
-  }
-});
-
-// Delete a service (POST method)
-router.post('/services/:id/delete', async (req, res) => {
-  try {
-    await Service.findByIdAndDelete(req.params.id);
-    res.redirect('/my-services'); // After deleting, go back to list
+    if (!service) return res.status(404).send("Service not found");
+    return res.render("services/edit", {
+      service,
+      title: `Edit: ${service.title}`,
+    });
   } catch (err) {
     console.error(err);
-    res.status(500).send('Error deleting service');
+    return res.status(500).send("Error loading service");
   }
 });
 
+// Update (simple form POST)
+router.post("/:id", protect, async (req, res) => {
+  try {
+    const { title, description, category, status, price, imageUrl } = req.body;
+    await Service.findByIdAndUpdate(
+      req.params.id,
+      { title, description, category, status, price, imageUrl },
+      { new: true }
+    );
+    return res.redirect(`/services/${req.params.id}`);
+  } catch (err) {
+    console.error(err);
+    return res.status(500).send("Error updating service");
+  }
+});
+
+// Delete (form POST)
+router.post("/:id/delete", protect, async (req, res) => {
+  try {
+    await Service.findByIdAndDelete(req.params.id);
+    return res.redirect("/my-services");
+  } catch (err) {
+    console.error(err);
+    return res.status(500).send("Error deleting service");
+  }
+});
+
+// Detail (must be AFTER edit/delete form routes)
+router.get("/:id", serviceController.getServiceById);
+
+// Optional REST-style endpoints
+router.put("/:id", protect, serviceController.updateService);
+router.delete("/:id", protect, serviceController.deleteService);
 
 module.exports = router;

--- a/server.js
+++ b/server.js
@@ -1,20 +1,21 @@
-const path = require('path');
-const express = require('express');
-const dotenv = require('dotenv');
-const expressLayouts = require('express-ejs-layouts');
-const connectDB = require('./config/db');
-const cookieParser = require('cookie-parser');
+const path = require("path");
+const express = require("express");
+const dotenv = require("dotenv");
+const expressLayouts = require("express-ejs-layouts");
+const connectDB = require("./config/db");
+const cookieParser = require("cookie-parser");
 const session = require("express-session");
+const methodOverride = require("method-override");
+
+// --- Controllers ---
+const serviceController = require("./controllers/serviceController");
 
 // --- Import Route Files ---
-const pageRoutes = require('./routes/pageRoutes');
-const userRoutes = require('./routes/userRoutes');
-const serviceRoutes = require('./routes/serviceRoutes');
-const reviewRoutes = require('./routes/reviewRoutes'); 
-const bookingRoutes = require('./routes/bookingRoutes'); 
-const Service = require('./models/service');
-const methodOverride = require('method-override');
- 
+const pageRoutes = require("./routes/pageRoutes");
+const userRoutes = require("./routes/userRoutes");
+const serviceRoutes = require("./routes/serviceRoutes");
+const reviewRoutes = require("./routes/reviewRoutes");
+const bookingRoutes = require("./routes/bookingRoutes");
 
 // --- Core Setup ---
 dotenv.config();
@@ -25,51 +26,55 @@ const app = express();
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
 app.use(cookieParser());
-app.use(methodOverride('_method'));
+app.use(methodOverride("_method"));
 app.use(express.static(path.join(__dirname, "public")));
 
+// 🔎 Logger (useful for debugging, optional)
+app.use((req, _res, next) => {
+  console.log("HIT:", req.method, req.url);
+  next();
+});
 
 // --- View Engine Setup ---
-app.set('view engine', 'ejs');
-app.set('views', path.join(__dirname, 'views'));
+app.set("view engine", "ejs");
+app.set("views", path.join(__dirname, "views"));
 app.use(expressLayouts);
-app.set('layout', 'layouts/main');
+app.set("layout", "layouts/main");
 
-//session middleware
-app.use(session({
-  secret: process.env.SESSION_SECRET || "dev-secret",
-  resave: false,
-  saveUninitialized: true,
-  cookie: { secure: false } // secure:true only if HTTPS
-}));
+// --- Session middleware ---
+app.use(
+  session({
+    secret: process.env.SESSION_SECRET || "dev-secret",
+    resave: false,
+    saveUninitialized: true,
+    cookie: { secure: false }, // set secure:true only if HTTPS
+  })
+);
 
 // --- Global Variables for Views ---
 app.use((req, res, next) => {
   res.locals.user = req.user || null;
-  res.locals.title = 'SkillLink';
+  res.locals.title = "SkillLink";
   next();
 });
 
+// --- ROUTES (order matters) ---
+// 1. APIs
+app.use("/auth", userRoutes);
+app.use("/api/reviews", reviewRoutes);
+app.use("/api/bookings", bookingRoutes);
 
+// 2. Services — include shim for details
+app.get("/services/:id", serviceController.getServiceById);
+app.use("/services", serviceRoutes);
 
-// --- ROUTES ---
-// Page-rendering routes (handled by pageRoutes.js)
-app.use('/', pageRoutes);
-// API routes (prefixed with /auth)
-app.use('/auth', userRoutes);
-app.use('/api/services', serviceRoutes);
-app.use('/api/reviews', reviewRoutes);
+// 3. Page routes (catch-all last)
+app.use("/", pageRoutes);
 
-// booking routes
-app.use('/api/bookings', bookingRoutes);
-
-
-
-// --- 404 Handler 
+// --- 404 Handler (LAST) ---
 app.use((_req, res) => {
-    res.status(404).send("Error 404: Page Not Found");
+  res.status(404).send("Error 404: Page Not Found");
 });
-
 
 // --- Server Initialization ---
 const PORT = process.env.PORT || 3000;

--- a/views/account/bookings.ejs
+++ b/views/account/bookings.ejs
@@ -1,70 +1,114 @@
 <% /* views/account/bookings.ejs */ %>
 <section class="account-wrap">
-  <%- include('../partials/accountSidebar', { active: 'bookings', user, stats }) %>
+  <%- include('../partials/accountSidebar', { active: 'bookings', user, stats })
+  %>
 
   <main class="account-main">
     <h4 class="no-margin">Bookings</h4>
     <p class="muted small">Create a new booking or manage your requests.</p>
 
     <% if (typeof flash !== 'undefined' && flash) { %>
-      <div class="card-panel green lighten-4 green-text text-darken-4"><%= flash %></div>
+    <div class="card-panel green lighten-4 green-text text-darken-4">
+      <%= flash %>
+    </div>
     <% } %>
 
     <!-- ===== New Booking ===== -->
-    <div class="card z-depth-1 booking-new" style="margin-bottom:20px;">
+    <div class="card z-depth-1 booking-new" style="margin-bottom: 20px">
       <div class="card-content">
         <h5>New Booking</h5>
-        <p class="tiny muted">Choose a service, pick a time, and add notes. The provider will be notified.</p>
+        <p class="tiny muted">
+          Choose a service, pick a time, and add notes. The provider will be
+          notified.
+        </p>
 
         <!-- handled by public/js/bookings.js -->
-        <form id="new-booking-form" style="margin:0;">
+        <form id="new-booking-form" style="margin: 0">
           <div class="booking-form-grid">
-            <% if (typeof selectedService !== 'undefined' && selectedService) { %>
-              <input type="hidden" name="serviceId" value="<%= selectedService._id %>">
-              <div class="input-field">
-                <label class="active">Service</label>
-                <input type="text" value="<%= selectedService.title %>" disabled>
-                <small class="muted">Price: $<%= selectedService.price || 0 %></small>
-              </div>
+            <% if (typeof selectedService !== 'undefined' && selectedService) {
+            %>
+            <input
+              type="hidden"
+              name="serviceId"
+              value="<%= selectedService._id %>"
+            />
+            <div class="input-field">
+              <label class="active">Service</label>
+              <input
+                type="text"
+                value="<%= selectedService.title %>"
+                disabled
+              />
+              <small class="muted"
+                >Price: $<%= selectedService.price || 0 %></small
+              >
+            </div>
             <% } else { %>
-              <div class="input-field">
-                <label class="active" for="serviceId">Service</label>
-                <select id="serviceId" name="serviceId" required>
-                  <option value="" disabled selected>Select a service…</option>
-                  <% (typeof servicesToBook !== 'undefined' ? servicesToBook : []).forEach(function(s){ %>
-                    <option value="<%= s._id %>">
-                      <%= s.title %> <% if (typeof s.price !== 'undefined') { %> — $<%= s.price %><% } %>
-                    </option>
-                  <% }) %>
-                </select>
-              </div>
+            <div class="input-field">
+              <label class="active" for="serviceId">Service</label>
+              <select id="serviceId" name="serviceId" required>
+                <option value="" disabled selected>Select a service…</option>
+                <% (typeof servicesToBook !== 'undefined' ? servicesToBook :
+                []).forEach(function(s){ %>
+                <option value="<%= s._id %>">
+                  <%= s.title %> <% if (typeof s.price !== 'undefined') { %> —
+                  $<%= s.price %><% } %>
+                </option>
+                <% }) %>
+              </select>
+            </div>
             <% } %>
 
             <div class="input-field">
               <label class="active" for="date">Date</label>
-              <input id="date" type="date" name="date" required min="<%= new Date().toISOString().split('T')[0] %>">
+              <input
+                id="date"
+                type="date"
+                name="date"
+                required
+                min="<%= new Date().toISOString().split('T')[0] %>"
+              />
             </div>
 
             <div class="input-field">
               <label class="active" for="time">Time</label>
-              <input id="time" type="time" name="time" required>
+              <input id="time" type="time" name="time" required />
             </div>
 
             <div class="input-field">
               <label class="active" for="durationHours">Duration (hours)</label>
-              <input id="durationHours" type="number" name="durationHours" min="1" max="12" value="1" required>
+              <input
+                id="durationHours"
+                type="number"
+                name="durationHours"
+                min="1"
+                max="12"
+                value="1"
+                required
+              />
             </div>
           </div>
 
-          <div class="input-field" style="margin-top:12px;">
-            <label class="active" for="notes">Notes to provider (optional)</label>
-            <textarea id="notes" class="materialize-textarea" name="notes" maxlength="2000"
-              placeholder="Briefly describe what you need…"></textarea>
+          <div class="input-field" style="margin-top: 12px">
+            <label class="active" for="notes"
+              >Notes to provider (optional)</label
+            >
+            <textarea
+              id="notes"
+              class="materialize-textarea"
+              name="notes"
+              maxlength="2000"
+              placeholder="Briefly describe what you need…"
+            ></textarea>
           </div>
 
-          <div style="margin-top:10px;">
-            <button type="submit" class="btn indigo">SEND BOOKING REQUEST</button>
-            <span class="booking-help">No charge until accepted.</span>
+          <div style="margin-top: 10px">
+            <button type="submit" class="btn indigo">
+              SEND BOOKING REQUEST
+            </button>
+            <span class="booking-help"
+              >No credits deducted until accepted.</span
+            >
           </div>
         </form>
       </div>
@@ -74,52 +118,75 @@
     <h5 class="bookings-section-title">Your Requests</h5>
 
     <ul class="collection">
-      <% (bookings || []).forEach(function(b){ 
-           var amProvider = String(user._id) === String(b.provider && b.provider._id);
-           var serviceTitle = b.service ? b.service.title : 'Service';
-           var providerName = (b.provider ? ((b.provider.firstName || '') + ' ' + (b.provider.lastName || '')) : '');
-           var requesterName = (b.requester ? ((b.requester.firstName || '') + ' ' + (b.requester.lastName || '')) : '');
-           var statusClass = (b.status === 'Accepted') ? 'status-accepted' 
-                           : (b.status === 'Declined' || b.status === 'Cancelled') ? 'status-declined' 
-                           : 'status-pending';
-      %>
-        <li class="collection-item">
-          <div>
-            <div style="display:flex; align-items:center; gap:10px; flex-wrap:wrap;">
-              <strong><%= serviceTitle %></strong>
-              <span class="status-badge <%= statusClass %>"><%= b.status %></span>
-            </div>
-
-            <div class="tiny muted" style="margin-top:4px;">
-              <% if (amProvider) { %>
-                Request from <%= requesterName %>
-              <% } else { %>
-                Provider: <%= providerName %>
-              <% } %>
-              <% if (b.start) { %> • <%= new Date(b.start).toLocaleString() %><% } %>
-            </div>
-
-            <% if (b.notes) { %>
-              <div class="booking-note"><em>Note:</em> <%= b.notes %></div>
-            <% } %>
+      <% (bookings || []).forEach(function(b){ var amProvider = String(user._id)
+      === String(b.provider && b.provider._id); var serviceTitle = b.service ?
+      b.service.title : 'Service'; var providerName = (b.provider ?
+      ((b.provider.firstName || '') + ' ' + (b.provider.lastName || '')) : '');
+      var requesterName = (b.requester ? ((b.requester.firstName || '') + ' ' +
+      (b.requester.lastName || '')) : ''); var statusClass = (b.status ===
+      'Accepted') ? 'status-accepted' : (b.status === 'Declined' || b.status ===
+      'Cancelled') ? 'status-declined' : 'status-pending'; %>
+      <li class="collection-item">
+        <div>
+          <div
+            style="
+              display: flex;
+              align-items: center;
+              gap: 10px;
+              flex-wrap: wrap;
+            "
+          >
+            <strong><%= serviceTitle %></strong>
+            <span class="status-badge <%= statusClass %>"><%= b.status %></span>
           </div>
 
-          <div class="booking-actions">
-            <a href="/services/<%= b.service ? b.service._id : '' %>" class="btn-flat">View</a>
-
-            <% if (amProvider && b.status === "Pending") { %>
-              <button type="button" class="btn-small green js-accept" data-id="<%= b._id %>">Accept</button>
-              <button type="button" class="btn-small red js-decline" data-id="<%= b._id %>">Decline</button>
-            <% } %>
+          <div class="tiny muted" style="margin-top: 4px">
+            <% if (amProvider) { %> Request from <%= requesterName %> <% } else
+            { %> Provider: <%= providerName %> <% } %> <% if (b.start) { %> •
+            <%= new Date(b.start).toLocaleString() %><% } %>
           </div>
 
-          <div class="quick-message">
-            <form class="js-quick-message" data-id="<%= b._id %>" style="display:flex; gap:10px; width:100%;">
-              <input name="text" placeholder="Send a quick message…">
-              <button type="submit" class="btn-small">Send</button>
-            </form>
-          </div>
-        </li>
+          <% if (b.notes) { %>
+          <div class="booking-note"><em>Note:</em> <%= b.notes %></div>
+          <% } %>
+        </div>
+
+        <div class="booking-actions">
+          <a
+            href="/services/<%= b.service ? b.service._id : '' %>"
+            class="btn-flat"
+            >View</a
+          >
+
+          <% if (amProvider && b.status === "Pending") { %>
+          <button
+            type="button"
+            class="btn-small green js-accept"
+            data-id="<%= b._id %>"
+          >
+            Accept
+          </button>
+          <button
+            type="button"
+            class="btn-small red js-decline"
+            data-id="<%= b._id %>"
+          >
+            Decline
+          </button>
+          <% } %>
+        </div>
+
+        <div class="quick-message">
+          <form
+            class="js-quick-message"
+            data-id="<%= b._id %>"
+            style="display: flex; gap: 10px; width: 100%"
+          >
+            <input name="text" placeholder="Send a quick message…" />
+            <button type="submit" class="btn-small">Send</button>
+          </form>
+        </div>
+      </li>
       <% }) %>
     </ul>
   </main>

--- a/views/account/dashboard.ejs
+++ b/views/account/dashboard.ejs
@@ -1,9 +1,8 @@
 <% /* views/account/dashboard.ejs */ %>
 <section class="account-wrap">
+  <!-- Sidebar links + quick stats -->
+  <%- include('../partials/accountSidebar', { active: 'dashboard', stats }) %>
 
-    <!-- Sidebar links + quick stats -->
-    <%- include('../partials/accountSidebar', { active: 'dashboard', stats }) %>
-  
   <main class="account-main">
     <!-- Top bar -->
     <div class="account-top row">
@@ -53,114 +52,114 @@
     </div>
 
     <!-- My Skills -->
-  <div class="row eq">
-    <div class="row">
-      <div class="col s12 m6">
-        <div class="card">
-          <div class="card-content">
-            <span class="card-title">My Skills</span>
-            <ul class="collection">
-              <li class="collection-item">
-                <span
-                  class="badge new"
-                  data-badge-caption="12 requests this month"
-                ></span>
-                <strong>Graphic Design</strong>
-                <span class="chip">Creative</span>
-                <div class="tiny grey-text">
-                  Branding, digital illustrations for businesses
-                </div>
-                <div class="right-align">
-                  <a href="/skills" class="tiny">Edit</a>
-                </div>
-              </li>
-              <li class="collection-item">
-                <span
-                  class="badge"
-                  data-badge-caption="8 requests this month"
-                ></span>
-                <strong>Yoga Instruction</strong>
-                <span class="chip">Wellness</span>
-                <div class="tiny grey-text">
-                  Beginner to advanced sessions, meditation, mindfulness
-                </div>
-                <div class="right-align">
-                  <a href="/skills" class="tiny">Edit</a>
-                </div>
-              </li>
-            </ul>
+    <div class="row eq">
+      <div class="row">
+        <div class="col s12 m6">
+          <div class="card">
+            <div class="card-content">
+              <span class="card-title">My Skills</span>
+              <ul class="collection">
+                <li class="collection-item">
+                  <span
+                    class="badge new"
+                    data-badge-caption="12 requests this month"
+                  ></span>
+                  <strong>Graphic Design</strong>
+                  <span class="chip">Creative</span>
+                  <div class="tiny grey-text">
+                    Branding, digital illustrations for businesses
+                  </div>
+                  <div class="right-align">
+                    <a href="/skills" class="tiny">Edit</a>
+                  </div>
+                </li>
+                <li class="collection-item">
+                  <span
+                    class="badge"
+                    data-badge-caption="8 requests this month"
+                  ></span>
+                  <strong>Yoga Instruction</strong>
+                  <span class="chip">Wellness</span>
+                  <div class="tiny grey-text">
+                    Beginner to advanced sessions, meditation, mindfulness
+                  </div>
+                  <div class="right-align">
+                    <a href="/skills" class="tiny">Edit</a>
+                  </div>
+                </li>
+              </ul>
+            </div>
           </div>
         </div>
-      </div>
 
-      <!-- Recent Activity (+ rating widget) -->
-      <div class="col s12 m6">
-        <div class="card">
-          <div class="card-content">
-            <span class="card-title">Recent Activity</span>
+        <!-- Recent Activity (+ rating widget) -->
+        <div class="col s12 m6">
+          <div class="card">
+            <div class="card-content">
+              <span class="card-title">Recent Activity</span>
 
-            <!-- Activity item with rating -->
-            <div class="activity-item">
-              <i class="material-icons green-text">check_circle</i>
-              <div class="activity-body">
-                <div class="title">Service completed with John Smith</div>
-                <div class="caption">
-                  Yoga session • <strong>+2 credits</strong> earned • 2 hours
-                  ago
-                </div>
+              <!-- Activity item with rating -->
+              <div class="activity-item">
+                <i class="material-icons green-text">check_circle</i>
+                <div class="activity-body">
+                  <div class="title">Service completed with John Smith</div>
+                  <div class="caption">
+                    Yoga session • <strong>+2 credits</strong> earned • 2 hours
+                    ago
+                  </div>
 
-                <!-- Rating widget -->
-                <form class="rating-form" action="/ratings" method="POST">
-                  <input type="hidden" name="bookingId" value="bk_123_demo" />
-                  <div class="stars" data-stars>
-                    <% for (let i=1;i<=5;i++){ %>
-                    <i class="material-icons" data-star="<%= i %>"
-                      >star_border</i
+                  <!-- Rating widget -->
+                  <form class="rating-form" action="/ratings" method="POST">
+                    <input type="hidden" name="bookingId" value="bk_123_demo" />
+                    <div class="stars" data-stars>
+                      <% for (let i=1;i<=5;i++){ %>
+                      <i class="material-icons" data-star="<%= i %>"
+                        >star_border</i
+                      >
+                      <% } %>
+                    </div>
+                    <div class="input-field">
+                      <textarea
+                        name="comment"
+                        id="ratingComment"
+                        class="materialize-textarea"
+                        placeholder="Leave a short review (optional)"
+                      ></textarea>
+                      <label for="ratingComment">Review</label>
+                    </div>
+                    <button
+                      type="submit"
+                      class="btn-small indigo waves-effect waves-light"
                     >
-                    <% } %>
-                  </div>
-                  <div class="input-field">
-                    <textarea
-                      name="comment"
-                      id="ratingComment"
-                      class="materialize-textarea"
-                      placeholder="Leave a short review (optional)"
-                    ></textarea>
-                    <label for="ratingComment">Review</label>
-                  </div>
-                  <button
-                    type="submit"
-                    class="btn-small indigo waves-effect waves-light"
-                  >
-                    Submit rating
-                  </button>
-                </form>
-              </div>
-            </div>
-
-            <div class="activity-item">
-              <i class="material-icons blue-text">mark_email_unread</i>
-              <div class="activity-body">
-                <div class="title">New service request received</div>
-                <div class="caption">
-                  Logo design from Emma Wilson • 5 hours ago
+                      Submit rating
+                    </button>
+                  </form>
                 </div>
               </div>
-            </div>
 
-            <div class="activity-item">
-              <i class="material-icons amber-text">star</i>
-              <div class="activity-body">
-                <div class="title">New 5-star review received</div>
-                <div class="caption">
-                  From Michael Brown for graphic design • 1 day ago
+              <div class="activity-item">
+                <i class="material-icons blue-text">mark_email_unread</i>
+                <div class="activity-body">
+                  <div class="title">New service request received</div>
+                  <div class="caption">
+                    Logo design from Emma Wilson • 5 hours ago
+                  </div>
+                </div>
+              </div>
+
+              <div class="activity-item">
+                <i class="material-icons amber-text">star</i>
+                <div class="activity-body">
+                  <div class="title">New 5-star review received</div>
+                  <div class="caption">
+                    From Michael Brown for graphic design • 1 day ago
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
     </div>
 
     <!-- Pending Requests (actionable) -->

--- a/views/auth/login.ejs
+++ b/views/auth/login.ejs
@@ -152,6 +152,74 @@
       }
     </style>
   </head>
+  <script>
+    (function () {
+      function toast(msg) {
+        if (window.M && M.toast) M.toast({ html: msg, displayLength: 2500 });
+        else alert(msg);
+      }
+
+      const form = document.getElementById("loginForm");
+      if (!form) return;
+
+      form.addEventListener("submit", async function (e) {
+        // Progressive enhancement: try AJAX first; fall back if not JSON.
+        e.preventDefault();
+
+        const fd = new FormData(form);
+        const body = {
+          email: fd.get("email"),
+          password: fd.get("password"),
+          remember: !!fd.get("remember"),
+        };
+
+        // next comes from URL (?next=/bookings) or defaults to /dashboard
+        const next =
+          new URLSearchParams(location.search).get("next") || "/dashboard";
+
+        try {
+          const res = await fetch(form.action || "/auth/login", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Accept: "application/json",
+            },
+            credentials: "same-origin",
+            body: JSON.stringify(body),
+          });
+
+          const ct = res.headers.get("content-type") || "";
+          // If server didn't return JSON (e.g., rendered HTML/redirect), fall back to normal submit.
+          if (!ct.includes("application/json")) {
+            form.removeEventListener("submit", arguments.callee);
+            form.submit();
+            return;
+          }
+
+          const data = await res.json().catch(() => ({}));
+
+          if (!res.ok) {
+            toast(data.message || "Login failed");
+            return;
+          }
+
+          // If server gives us a token, store it for API calls (Bearer flow)
+          if (data.token) {
+            try {
+              localStorage.setItem("token", data.token);
+            } catch (e) {}
+          }
+          // If server set an httpOnly cookie, we won’t see it here — but redirect still works.
+          location.href = data.next || next;
+        } catch (err) {
+          // Network/CORS/etc → fall back to standard submit so existing flow works
+          form.removeEventListener("submit", arguments.callee);
+          form.submit();
+        }
+      });
+    })();
+  </script>
+
   <body>
     <div class="row" style="margin: 0">
       <!-- LEFT: gradient panel (content pushed down) -->

--- a/views/auth/register.ejs
+++ b/views/auth/register.ejs
@@ -101,6 +101,75 @@
       }
     </style>
   </head>
+  <script>
+    (function () {
+      function toast(msg) {
+        if (window.M && M.toast) M.toast({ html: msg, displayLength: 2500 });
+        else alert(msg);
+      }
+
+      const form = document.getElementById("registerForm");
+      if (!form) return;
+
+      form.addEventListener("submit", async function (e) {
+        e.preventDefault();
+
+        const fd = new FormData(form);
+        const body = {
+          firstName: fd.get("firstName"),
+          lastName: fd.get("lastName"),
+          email: fd.get("email"),
+          password: fd.get("password"),
+          accept: !!fd.get("accept"),
+        };
+
+        // Allow redirect to ?next=... after signup; default to /dashboard
+        const next =
+          new URLSearchParams(location.search).get("next") || "/dashboard";
+
+        try {
+          const res = await fetch(form.action || "/auth/register", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Accept: "application/json",
+            },
+            credentials: "same-origin",
+            body: JSON.stringify(body),
+          });
+
+          const ct = res.headers.get("content-type") || "";
+          if (!ct.includes("application/json")) {
+            // Server is likely doing a standard redirect or rendering — preserve original flow
+            form.removeEventListener("submit", arguments.callee);
+            form.submit();
+            return;
+          }
+
+          const data = await res.json().catch(() => ({}));
+
+          if (!res.ok) {
+            toast(data.message || "Registration failed");
+            return;
+          }
+
+          // If controller returns a token, save it; otherwise rely on cookie the server set.
+          if (data.token) {
+            try {
+              localStorage.setItem("token", data.token);
+            } catch (e) {}
+          }
+
+          location.href = data.next || next;
+        } catch (err) {
+          // Fallback to normal submit on errors
+          form.removeEventListener("submit", arguments.callee);
+          form.submit();
+        }
+      });
+    })();
+  </script>
+
   <body>
     <div class="row" style="margin: 0">
       <!-- Left: light panel + form -->

--- a/views/services.ejs
+++ b/views/services.ejs
@@ -77,7 +77,7 @@
   <div class="services-grid">
   <% (services || []).forEach(function (s) { %>
     <div class="service-card">
-      <!-- ✅ Fallback to Pravatar or Unsplash if no s.img -->
+      <!--  Fallback to Pravatar or Unsplash if no s.img -->
       <img
           src="<%= s.img || ('https://placehold.co/600x400?text=' + encodeURIComponent(s.title)) %>"
           alt="<%= s.title %>"

--- a/views/services/serviceDetails.ejs
+++ b/views/services/serviceDetails.ejs
@@ -1,0 +1,99 @@
+<section class="container service-details">
+  <div class="sd-hero card z-depth-0">
+    <div class="sd-hero-main">
+      <div>
+        <h3 class="sd-title"><%= service.title %></h3>
+        <% if (service.category) { %>
+          <div class="sd-chips">
+            <span class="chip"><%= service.category %></span>
+            <span class="chip light">Service</span>
+          </div>
+        <% } %>
+      </div>
+      <div class="sd-price-pill">
+        <div class="sd-price-label">From</div>
+        <div class="sd-price-amount">$<%= service.price || 0 %></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row sd-grid">
+    <div class="col s12 m7 l8">
+      <!-- <div class="card z-depth-1 sd-cover">
+        <img
+          src="<%= service.imageUrl || ('https://source.unsplash.com/960x540/?' + encodeURIComponent(service.category || service.title || 'workspace,tools,abstract')) %>"
+          alt="<%= service.title %>">
+      </div> -->
+
+      <div class="card z-depth-1">
+        <div class="card-content">
+          <h6 class="section-label">What you’ll get</h6>
+          <ul class="sd-list">
+            <li><i class="material-icons">check_circle</i> Tailored help for your needs</li>
+            <li><i class="material-icons">check_circle</i> Clear deliverables & timeline</li>
+            <li><i class="material-icons">check_circle</i> One round of revisions</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="card z-depth-1">
+        <div class="card-content">
+          <h6 class="section-label">About this service</h6>
+          <p><%= service.description || 'The provider has not added a full description yet.' %></p>
+        </div>
+      </div>
+
+      <div class="card z-depth-1">
+        <div class="card-content sd-provider">
+          <div class="sd-provider-left">
+            <img class="circle avatar"
+                 src="<%= (service.user && service.user.avatar) ? service.user.avatar : ('https://i.pravatar.cc/120?u=' + (service.user ? service.user._id : 'provider')) %>"
+                 alt="Provider">
+            <div>
+              <div class="name">
+                <%= service.user ? ((service.user.firstName || '') + ' ' + (service.user.lastName || '')) : 'Provider' %>
+              </div>
+              <div class="muted"><%= (service.user && service.user.title) ? service.user.title : 'Skill Provider' %></div>
+              <div class="tiny muted"><%= (service.user && service.user.email) ? service.user.email : '' %></div>
+            </div>
+          </div>
+          <div class="sd-provider-right">
+            <a href="/messages" class="btn-flat">Message</a>
+          </div>
+        </div>
+      </div>
+
+      <ul class="collapsible sd-faq">
+        <li>
+          <div class="collapsible-header"><i class="material-icons">help_outline</i>How does booking work?</div>
+          <div class="collapsible-body"><span>Request a booking with your preferred date/time. The provider can accept, decline, or message you to adjust details.</span></div>
+        </li>
+        <li>
+          <div class="collapsible-header"><i class="material-icons">schedule</i>Can I reschedule?</div>
+          <div class="collapsible-body"><span>Yes—use the message box after booking to discuss a new time.</span></div>
+        </li>
+      </ul>
+    </div>
+
+<div class="col s12 m5 l4">
+  <div class="card z-depth-1 sd-sticky">
+    <div class="card-content">
+      <h5>Request a Booking</h5>
+
+      <!-- Direct link to bookings -->
+      <a href="/bookings" class="btn indigo btn-block">Go to Bookings</a>
+      <p class="tiny muted sd-safe">Manage your bookings and requests.</p>
+    </div>
+  </div>
+
+  <div class="card z-depth-1">
+    <div class="card-content sd-facts">
+      <div><i class="material-icons">verified_user</i> Secure requests</div>
+      <div><i class="material-icons">event_available</i> Flexible scheduling</div>
+      <div><i class="material-icons">chat_bubble_outline</i> Built-in messaging</div>
+    </div>
+  </div>
+</div>
+
+  </div>
+</section>


### PR DESCRIPTION
Frontend (EJS)

Updated views/account/bookings.ejs to display Accept and Decline buttons for bookings that are in Pending status and where the logged-in user is the provider.

Added conditional rendering logic to ensure buttons are only visible to providers.

Included buttons alongside booking details, next to the View and Quick Message actions.

Frontend (JS)

Updated public/js/bookings.js to handle button clicks.

Added event listeners for .js-accept and .js-decline buttons to send POST requests to:

/api/bookings/:id/accept

/api/bookings/:id/decline

Implemented toast notifications for success/failure feedback.

Backend (API)

Extended booking API routes to support acceptance/decline actions.

Added logic to update booking status and ensure proper authorization (only providers can accept/decline).

Linked messages with threads so providers/requesters can continue communication after decision.

✅ How It Works

A provider sees all pending requests in Bookings ---> Your Requests.

If they are the provider for a pending booking, Accept and Decline buttons are displayed.

Clicking Accept/Decline:

Sends an AJAX request via bookings.js.

Updates booking status in the database.

Refreshes the page with updated status badges.

Displays confirmation toast (Accepted or Declined).